### PR TITLE
feat: add mobile touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,17 @@
       <div id="interaction" class="interaction-prompt">
         <span id="interactionText">Eキーで調べる</span>
       </div>
+
+      <!-- モバイル操作UI -->
+      <div class="mobile-controls" id="mobileControls">
+        <div class="dpad">
+          <button class="up" data-key="KeyW" aria-label="前に進む">▲</button>
+          <button class="left" data-key="KeyA" aria-label="左に移動">◀</button>
+          <button class="down" data-key="KeyS" aria-label="後ろに下がる">▼</button>
+          <button class="right" data-key="KeyD" aria-label="右に移動">▶</button>
+        </div>
+        <button id="mobileInteract" class="interact" aria-label="調べる">◎</button>
+      </div>
     </section>
 
     <!-- 右側: 見取り図エリア -->

--- a/script.js
+++ b/script.js
@@ -261,18 +261,63 @@
       if (document.pointerLockElement === elements.game3d) {
         mouseX += e.movementX * 0.002;
         mouseY += e.movementY * 0.002;
-        
+
         mouseY = Math.max(-Math.PI/2, Math.min(Math.PI/2, mouseY));
-        
+
         camera.rotation.set(mouseY, mouseX, 0);
       }
     });
-    
+
     elements.game3d.addEventListener('click', () => {
       if (currentInteractable) {
         interactWithObject(currentInteractable);
       }
     });
+
+    // タッチ視点制御
+    let touchX = 0, touchY = 0;
+    elements.game3d.addEventListener('touchstart', (e) => {
+      if (e.touches.length === 1) {
+        touchX = e.touches[0].clientX;
+        touchY = e.touches[0].clientY;
+      }
+    }, { passive: false });
+
+    elements.game3d.addEventListener('touchmove', (e) => {
+      if (e.touches.length === 1) {
+        const dx = e.touches[0].clientX - touchX;
+        const dy = e.touches[0].clientY - touchY;
+        touchX = e.touches[0].clientX;
+        touchY = e.touches[0].clientY;
+        mouseX += dx * 0.002;
+        mouseY -= dy * 0.002;
+        mouseY = Math.max(-Math.PI/2, Math.min(Math.PI/2, mouseY));
+        camera.rotation.set(mouseY, mouseX, 0);
+      }
+      e.preventDefault();
+    }, { passive: false });
+
+    // モバイル移動ボタン
+    document.querySelectorAll('.mobile-controls button[data-key]').forEach(btn => {
+      btn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        keys[btn.dataset.key] = true;
+      }, { passive: false });
+      btn.addEventListener('touchend', (e) => {
+        e.preventDefault();
+        keys[btn.dataset.key] = false;
+      });
+    });
+
+    const mobileInteract = document.getElementById('mobileInteract');
+    if (mobileInteract) {
+      mobileInteract.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        if (currentInteractable) {
+          interactWithObject(currentInteractable);
+        }
+      }, { passive: false });
+    }
   }
 
   // ========= プレイヤー移動処理 =========

--- a/style.css
+++ b/style.css
@@ -309,8 +309,53 @@ canvas#blueprint {
 }
 
 .toast.show {
-  opacity: 1; 
+  opacity: 1;
   transform: translateX(-50%) translateY(10px);
+}
+
+/* ========= モバイル用操作ボタン ========= */
+.mobile-controls {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  z-index: 50;
+}
+
+.dpad {
+  position: relative;
+  width: 120px;
+  height: 120px;
+}
+
+.dpad button {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--fg);
+  font-size: 20px;
+}
+
+.dpad button.up { top: 0; left: 40px; }
+.dpad button.left { top: 40px; left: 0; }
+.dpad button.down { top: 80px; left: 40px; }
+.dpad button.right { top: 40px; left: 80px; }
+
+.mobile-controls button.interact {
+  width: 60px;
+  height: 60px;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  color: var(--fg);
+  font-size: 14px;
 }
 
 /* ========= スマホ対応（レスポンシブ） ========= */
@@ -332,9 +377,8 @@ canvas#blueprint {
     height: 200px;
   }
   
-  .movement-hint .hint-text {
-    font-size: 10px;
-  }
+  .movement-hint { display: none; }
+  .mobile-controls { display: flex; }
   
   .legend {
     font-size: 10px;
@@ -359,16 +403,11 @@ canvas#blueprint {
     padding: 8px;
     gap: 12px;
   }
-  
+
   .main-3d {
     min-height: 300px;
   }
-  
-  .movement-hint {
-    bottom: 10px;
-    padding: 6px 12px;
-  }
-  
+
   canvas#blueprint {
     height: 150px;
   }


### PR DESCRIPTION
## Summary
- add on-screen D-pad and interact button for mobile
- support touch-based camera movement
- style mobile controls and hide keyboard hints on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689716839fb08330ad2656554c88a27e